### PR TITLE
Enable slow-motion auto-rotating gallery carousel

### DIFF
--- a/index.html
+++ b/index.html
@@ -42,9 +42,12 @@
     <h2>Οι Περιπέτειές μας</h2>
     <div class="slider">
       <div class="slides">
-        <img src="https://images.unsplash.com/photo-1525253086316-d0c936c814f8" alt="Dog adventure 1" />
-        <img src="https://images.unsplash.com/photo-1517849845537-4d257902454a" alt="Dog adventure 2" />
-        <img src="https://images.unsplash.com/photo-1517423440428-a5a00ad493e8" alt="Dog adventure 3" />
+        <div class="slide"><img src="https://images.unsplash.com/photo-1525253086316-d0c936c814f8" alt="Dog adventure 1" /></div>
+        <div class="slide"><img src="https://images.unsplash.com/photo-1517849845537-4d257902454a" alt="Dog adventure 2" /></div>
+        <div class="slide"><img src="https://images.unsplash.com/photo-1517423440428-a5a00ad493e8" alt="Dog adventure 3" /></div>
+        <div class="slide"><img src="https://images.unsplash.com/photo-1525253086316-d0c936c814f8" alt="Dog adventure 1" /></div>
+        <div class="slide"><img src="https://images.unsplash.com/photo-1517849845537-4d257902454a" alt="Dog adventure 2" /></div>
+        <div class="slide"><img src="https://images.unsplash.com/photo-1517423440428-a5a00ad493e8" alt="Dog adventure 3" /></div>
       </div>
     </div>
   </section>

--- a/script.js
+++ b/script.js
@@ -1,14 +1,4 @@
 document.addEventListener('DOMContentLoaded', () => {
-  const slides = document.querySelector('.slides');
-  if (slides) {
-    let index = 0;
-    const total = slides.children.length;
-    setInterval(() => {
-      index = (index + 1) % total;
-      slides.style.transform = `translateX(-${index * 100}%)`;
-    }, 5000); // change slide every 5 seconds
-  }
-
   document.querySelectorAll('.faq-item button').forEach(btn => {
     btn.addEventListener('click', () => {
       btn.nextElementSibling.classList.toggle('open');

--- a/styles.css
+++ b/styles.css
@@ -88,12 +88,26 @@ nav a {
 
 .slides {
   display: flex;
-  transition: transform 1s ease;
+  animation: scroll 60s linear infinite;
 }
 
-.slides img {
-  width: 100%;
-  flex-shrink: 0;
+.slide {
+  flex: 0 0 100%;
+  display: flex;
+  justify-content: center;
+}
+
+.slide img {
+  width: 25%;
+}
+
+@keyframes scroll {
+  0% {
+    transform: translateX(0);
+  }
+  100% {
+    transform: translateX(-50%);
+  }
 }
 
 .faq-item {


### PR DESCRIPTION
## Summary
- Add auto-scrolling gallery carousel that loops slowly in Greek "Οι Περιπέτειές μας" section
- Shrink gallery images to one-quarter size and center them in each slide
- Simplify JavaScript by removing slide timer, keeping FAQ toggle only

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b0b0f7e3d88320a4cbde6838f32082