### PR TITLE
Add 5mm spacing between carousel images

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -98,6 +98,7 @@ nav a {
 .slides {
   display: flex;
   animation: scroll 60s linear infinite;
+  gap: 5mm;
 }
 
 .slide {


### PR DESCRIPTION
## Summary
- add 5mm gap between carousel slides for consistent photo spacing

## Testing
- `npm test` (fails: Could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_68b0baf3fad48320b3c35d1807de035b