### PR TITLE
Add bone-shaped mobile hamburger menu

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,7 +12,11 @@
       <a href="https://mastereat.github.io/dogspot/">
         <img src="images/logo.png" alt="Rocky & Ruby Dog Spot logo" class="logo" />
       </a>
-      <button class="menu-toggle" aria-label="Toggle navigation" aria-expanded="false">☰</button>
+      <button class="menu-toggle" aria-label="Toggle navigation" aria-expanded="false">
+        <span></span>
+        <span></span>
+        <span></span>
+      </button>
       <nav>
         <ul>
           <li><a href="#hero">Home</a></li>
@@ -33,6 +37,29 @@
       </div>
     </div>
   </header>
+
+  <div class="mobile-menu" aria-hidden="true">
+    <nav class="mobile-nav">
+      <ul>
+        <li><a href="#hero">Home</a></li>
+        <li><a href="#blog">Blog</a></li>
+        <li><a href="#gallery">Gallery</a></li>
+      </ul>
+    </nav>
+    <img src="images/logo.png" alt="Rocky & Ruby Dog Spot logo" class="menu-logo" />
+    <div class="mobile-social">
+      <a href="https://facebook.com" target="_blank" rel="noopener">
+        <img src="images/facebook.svg" alt="Facebook" />
+      </a>
+      <a href="https://instagram.com" target="_blank" rel="noopener">
+        <img src="images/instagram.svg" alt="Instagram" />
+      </a>
+      <a href="https://tiktok.com" target="_blank" rel="noopener">
+        <img src="images/tiktok.svg" alt="TikTok" />
+      </a>
+    </div>
+    <p class="menu-email">info@rockyrubyspot.com</p>
+  </div>
 
   <section id="hero">
     <div class="hero-content">

--- a/script.js
+++ b/script.js
@@ -6,11 +6,12 @@ document.addEventListener('DOMContentLoaded', () => {
   });
 
   const menuToggle = document.querySelector('.menu-toggle');
-  const nav = document.querySelector('header nav');
-  if (menuToggle && nav) {
+  const mobileMenu = document.querySelector('.mobile-menu');
+  if (menuToggle && mobileMenu) {
     menuToggle.addEventListener('click', () => {
-      const open = nav.classList.toggle('open');
+      const open = mobileMenu.classList.toggle('open');
       menuToggle.setAttribute('aria-expanded', open);
+      mobileMenu.setAttribute('aria-hidden', !open);
     });
   }
 });

--- a/styles.css
+++ b/styles.css
@@ -25,11 +25,42 @@ header .container {
 
 .menu-toggle {
   display: none;
-  background: none;
-  border: none;
-  color: #fff;
-  font-size: 24px;
+  position: relative;
+  width: 40px;
+  height: 20px;
+  background: #fff;
+  border: 2px solid #333;
+  border-radius: 10px;
   cursor: pointer;
+}
+
+.menu-toggle::before,
+.menu-toggle::after {
+  content: '';
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 20px;
+  height: 20px;
+  background: #fff;
+  border: 2px solid #333;
+  border-radius: 50%;
+}
+
+.menu-toggle::before {
+  left: -12px;
+}
+
+.menu-toggle::after {
+  right: -12px;
+}
+
+.menu-toggle span {
+  display: block;
+  width: 18px;
+  height: 2px;
+  background: #333;
+  margin: 3px auto;
 }
 
 nav ul {
@@ -44,6 +75,50 @@ nav a {
   color: #fff;
   text-decoration: none;
   font-weight: bold;
+}
+
+.mobile-menu {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: #27D6F5;
+  color: #fff;
+  display: none;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 20px;
+  z-index: 1000;
+}
+
+.mobile-menu.open {
+  display: flex;
+}
+
+.mobile-menu nav ul {
+  flex-direction: column;
+  gap: 20px;
+}
+
+.mobile-menu nav a {
+  color: #fff;
+  font-size: 24px;
+  text-decoration: none;
+}
+
+.mobile-menu .mobile-social {
+  display: flex;
+  gap: 15px;
+}
+
+.mobile-menu .menu-logo {
+  width: 120px;
+}
+
+.mobile-menu .menu-email {
+  margin-top: 10px;
 }
 
 #hero {
@@ -181,6 +256,17 @@ footer .footer-social img {
 
 footer p {
   margin: 5px 0;
+}
+
+@media (max-width: 768px) {
+  header nav,
+  header .social-icons {
+    display: none;
+  }
+
+  .menu-toggle {
+    display: block;
+  }
 }
 
 @media (max-width: 600px) {


### PR DESCRIPTION
## Summary
- Add bone-shaped menu toggle button and mobile overlay with navigation, logo, social links, and email
- Style bone button and overlay menu; hide desktop navigation on small screens
- Toggle mobile menu with JavaScript and maintain accessibility attributes

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b0c45da1ec832099092acbd09415b1