### PR TITLE
Remove hamburger menu

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,7 +12,6 @@
       <a href="https://mastereat.github.io/dogspot/">
         <img src="images/logo.png" alt="Rocky & Ruby Dog Spot logo" class="logo" />
       </a>
-      <button class="menu-toggle" aria-label="Toggle navigation" aria-expanded="false">☰</button>
       <nav>
         <ul>
           <li><a href="#hero">Home</a></li>

--- a/script.js
+++ b/script.js
@@ -5,12 +5,4 @@ document.addEventListener('DOMContentLoaded', () => {
     });
   });
 
-  const menuToggle = document.querySelector('.menu-toggle');
-  const nav = document.querySelector('header nav');
-  if (menuToggle && nav) {
-    menuToggle.addEventListener('click', () => {
-      const open = nav.classList.toggle('open');
-      menuToggle.setAttribute('aria-expanded', open);
-    });
-  }
 });

--- a/styles.css
+++ b/styles.css
@@ -23,14 +23,6 @@ header .container {
   height: 100px;
 }
 
-.menu-toggle {
-  display: none;
-  background: none;
-  border: none;
-  color: #fff;
-  font-size: 24px;
-  cursor: pointer;
-}
 
 nav ul {
   list-style: none;


### PR DESCRIPTION
## Summary
- remove hamburger menu button and show navigation links directly
- drop unused toggle script and related styles

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b0c45da1ec832099092acbd09415b1