### PR TITLE
feat: add animated mobile menu with dark mode

### DIFF
--- a/images/hamburger.svg
+++ b/images/hamburger.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 100 60">
+  <path d="
+    M15,10 
+    C5,10 5,25 15,25 
+    C5,25 5,40 15,40 
+    C20,40 25,35 30,30 
+    L70,30 
+    C75,35 80,40 85,40 
+    C95,40 95,25 85,25 
+    C95,25 95,10 85,10 
+    C80,10 75,15 70,20 
+    L30,20 
+    C25,15 20,10 15,10
+    Z" 
+    fill="white"
+    stroke="black"
+    stroke-width="0.05"
+    stroke-linejoin="round"
+  />
+</svg>

--- a/index.html
+++ b/index.html
@@ -39,15 +39,17 @@
   </header>
 
   <div class="mobile-menu" aria-hidden="true">
-    <img src="images/logo.png" alt="Rocky & Ruby Dog Spot logo" class="menu-logo" />
-    <button class="theme-toggle" aria-label="Toggle dark mode">🌙</button>
-    <nav class="mobile-nav">
-      <ul>
-        <li><a href="#hero">Home</a></li>
-        <li><a href="#blog">Blog</a></li>
-        <li><a href="#gallery">Gallery</a></li>
-      </ul>
-    </nav>
+    <div class="menu-center">
+      <img src="images/logo.png" alt="Rocky & Ruby Dog Spot logo" class="menu-logo" />
+      <nav class="mobile-nav">
+        <ul>
+          <li><a href="#hero">Home</a></li>
+          <li><a href="#blog">Blog</a></li>
+          <li><a href="#gallery">Gallery</a></li>
+        </ul>
+      </nav>
+      <button class="theme-toggle" aria-label="Toggle dark mode">🌙</button>
+    </div>
     <div class="mobile-social">
       <a href="https://facebook.com" target="_blank" rel="noopener">
         <img src="images/facebook.svg" alt="Facebook" />

--- a/index.html
+++ b/index.html
@@ -10,8 +10,9 @@
   <header>
     <div class="container">
       <button id="menu-button" class="menu-button" aria-label="Menu" aria-expanded="false">
-        <img src="images/bone.svg" alt="menu" />
+        <img src="images/hamburger.svg" alt="menu" />
       </button>
+      <button id="theme-toggle" class="theme-toggle" aria-label="Toggle dark mode">🌙</button>
       <a href="https://mastereat.github.io/dogspot/">
         <img src="images/logo.png" alt="Rocky & Ruby Dog Spot logo" class="logo" />
       </a>
@@ -39,6 +40,7 @@
 
   <div class="mobile-menu" aria-hidden="true">
     <img src="images/logo.png" alt="Rocky & Ruby Dog Spot logo" class="menu-logo" />
+    <button class="theme-toggle" aria-label="Toggle dark mode">🌙</button>
     <nav class="mobile-nav">
       <ul>
         <li><a href="#hero">Home</a></li>

--- a/script.js
+++ b/script.js
@@ -6,6 +6,12 @@ document.addEventListener('DOMContentLoaded', () => {
   });
   const menuButton = document.getElementById('menu-button');
   const mobileMenu = document.querySelector('.mobile-menu');
+  const themeToggles = document.querySelectorAll('.theme-toggle');
+
+  const savedTheme = localStorage.getItem('theme');
+  if (savedTheme === 'dark') {
+    document.body.classList.add('dark-mode');
+  }
 
   menuButton.addEventListener('click', () => {
     mobileMenu.classList.toggle('open');
@@ -13,5 +19,13 @@ document.addEventListener('DOMContentLoaded', () => {
     const isOpen = mobileMenu.classList.contains('open');
     menuButton.setAttribute('aria-expanded', isOpen);
     mobileMenu.setAttribute('aria-hidden', !isOpen);
+  });
+
+  themeToggles.forEach(btn => {
+    btn.addEventListener('click', () => {
+      document.body.classList.toggle('dark-mode');
+      const theme = document.body.classList.contains('dark-mode') ? 'dark' : 'light';
+      localStorage.setItem('theme', theme);
+    });
   });
 });

--- a/styles.css
+++ b/styles.css
@@ -5,6 +5,20 @@ body {
   color: #333;
 }
 
+.theme-toggle {
+  background: none;
+  border: none;
+  font-size: 1.5rem;
+  cursor: pointer;
+  margin-left: 10px;
+  color: #fff;
+  transition: transform 0.3s ease;
+}
+
+.theme-toggle:hover {
+  transform: scale(1.1);
+}
+
 header {
   background: #27D6F5;
   color: #fff;
@@ -113,6 +127,43 @@ nav a:hover {
 
 .mobile-menu .menu-email {
   margin-top: 10px;
+}
+
+.mobile-menu .theme-toggle {
+  color: #27D6F5;
+  align-self: flex-end;
+}
+
+.mobile-menu nav li {
+  opacity: 0;
+  transform: translateX(20px);
+}
+
+.mobile-menu.open nav li {
+  animation: fadeInRight 0.3s forwards;
+}
+
+.mobile-menu.open nav li:nth-child(1) {
+  animation-delay: 0.1s;
+}
+
+.mobile-menu.open nav li:nth-child(2) {
+  animation-delay: 0.2s;
+}
+
+.mobile-menu.open nav li:nth-child(3) {
+  animation-delay: 0.3s;
+}
+
+@keyframes fadeInRight {
+  from {
+    opacity: 0;
+    transform: translateX(20px);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(0);
+  }
 }
 
 #hero {
@@ -286,4 +337,35 @@ footer p {
     justify-content: center;
     margin-top: 10px;
   }
+}
+
+/* Dark mode */
+body.dark-mode {
+  background: #121212;
+  color: #eee;
+}
+
+body.dark-mode header {
+  background: #111;
+}
+
+body.dark-mode nav a {
+  color: #fff;
+}
+
+body.dark-mode .mobile-menu {
+  background: #333;
+  color: #eee;
+}
+
+body.dark-mode footer {
+  background: #111;
+}
+
+body.dark-mode .theme-toggle {
+  color: #fff;
+}
+
+body.dark-mode .mobile-menu .theme-toggle {
+  color: #27D6F5;
 }

--- a/styles.css
+++ b/styles.css
@@ -77,6 +77,7 @@ nav a:hover {
   text-shadow: 0 0 8px rgba(0, 0, 0, 0.5);
 }
 
+
 .mobile-menu {
   position: fixed;
   top: 0;
@@ -92,8 +93,16 @@ nav a:hover {
   flex-direction: column;
   align-items: center;
   padding: 40px 20px;
-  gap: 20px;
   z-index: 1000;
+}
+
+.mobile-menu .menu-center {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 20px;
 }
 
 .mobile-menu.open {
@@ -121,6 +130,7 @@ nav a:hover {
   margin-top: auto;
 }
 
+
 .mobile-menu .menu-logo {
   width: 120px;
 }
@@ -129,9 +139,9 @@ nav a:hover {
   margin-top: 10px;
 }
 
+
 .mobile-menu .theme-toggle {
   color: #27D6F5;
-  align-self: flex-end;
 }
 
 .mobile-menu nav li {


### PR DESCRIPTION
## Summary
- use custom SVG button for mobile menu
- add dark mode toggle with persistence
- animate menu links as menu opens

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b0d2b08ff48320a4862666c115c29f