### PR TITLE
Add background text-shadow to navigation links

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -56,6 +56,11 @@ nav a {
   text-decoration: none;
   font-weight: bold;
   font-size: 18px;
+  transition: text-shadow 0.3s ease;
+}
+
+nav a:hover {
+  text-shadow: 0 0 12px rgba(0, 0, 0, 0.8);
 }
 
 .mobile-menu {


### PR DESCRIPTION
## Summary
- refactor nav link hover effect to use centered background-style text shadow across desktop and mobile
- intensify nav link hover shadow for stronger glow

## Testing
- `npm test` (fails: Could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_68b0d2179cb88320a664228912b39a8e