### PR TITLE
Remove dark mode toggle from header

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,7 +12,6 @@
       <button id="menu-button" class="menu-button" aria-label="Menu" aria-expanded="false">
         <img src="images/hamburger.svg" alt="menu" />
       </button>
-      <button id="theme-toggle" class="theme-toggle" aria-label="Toggle dark mode">🌙</button>
       <a href="https://mastereat.github.io/dogspot/">
         <img src="images/logo.png" alt="Rocky & Ruby Dog Spot logo" class="logo" />
       </a>
@@ -48,7 +47,6 @@
           <li><a href="#gallery">Gallery</a></li>
         </ul>
       </nav>
-      <button class="theme-toggle" aria-label="Toggle dark mode">🌙</button>
     </div>
     <div class="mobile-social">
       <a href="https://facebook.com" target="_blank" rel="noopener">

--- a/script.js
+++ b/script.js
@@ -6,12 +6,6 @@ document.addEventListener('DOMContentLoaded', () => {
   });
   const menuButton = document.getElementById('menu-button');
   const mobileMenu = document.querySelector('.mobile-menu');
-  const themeToggles = document.querySelectorAll('.theme-toggle');
-
-  const savedTheme = localStorage.getItem('theme');
-  if (savedTheme === 'dark') {
-    document.body.classList.add('dark-mode');
-  }
 
   menuButton.addEventListener('click', () => {
     mobileMenu.classList.toggle('open');
@@ -19,13 +13,5 @@ document.addEventListener('DOMContentLoaded', () => {
     const isOpen = mobileMenu.classList.contains('open');
     menuButton.setAttribute('aria-expanded', isOpen);
     mobileMenu.setAttribute('aria-hidden', !isOpen);
-  });
-
-  themeToggles.forEach(btn => {
-    btn.addEventListener('click', () => {
-      document.body.classList.toggle('dark-mode');
-      const theme = document.body.classList.contains('dark-mode') ? 'dark' : 'light';
-      localStorage.setItem('theme', theme);
-    });
   });
 });

--- a/styles.css
+++ b/styles.css
@@ -5,19 +5,7 @@ body {
   color: #333;
 }
 
-.theme-toggle {
-  background: none;
-  border: none;
-  font-size: 1.5rem;
-  cursor: pointer;
-  margin-left: 10px;
-  color: #fff;
-  transition: transform 0.3s ease;
-}
 
-.theme-toggle:hover {
-  transform: scale(1.1);
-}
 
 header {
   background: #27D6F5;
@@ -140,9 +128,6 @@ nav a:hover {
 }
 
 
-.mobile-menu .theme-toggle {
-  color: #27D6F5;
-}
 
 .mobile-menu nav li {
   opacity: 0;
@@ -349,33 +334,3 @@ footer p {
   }
 }
 
-/* Dark mode */
-body.dark-mode {
-  background: #121212;
-  color: #eee;
-}
-
-body.dark-mode header {
-  background: #111;
-}
-
-body.dark-mode nav a {
-  color: #fff;
-}
-
-body.dark-mode .mobile-menu {
-  background: #333;
-  color: #eee;
-}
-
-body.dark-mode footer {
-  background: #111;
-}
-
-body.dark-mode .theme-toggle {
-  color: #fff;
-}
-
-body.dark-mode .mobile-menu .theme-toggle {
-  color: #27D6F5;
-}


### PR DESCRIPTION
## Summary
- remove dark mode toggle from desktop and mobile headers
- drop dark mode scripts and styles

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b0dac838d483209f7ad5c4c37eab15